### PR TITLE
upgrade RegisterAccountLambda to python3.11

### DIFF
--- a/deployFalcon/cspm.yaml
+++ b/deployFalcon/cspm.yaml
@@ -752,9 +752,9 @@ Resources:
 
           os.chdir('/tmp')
           requirements = open("requirements.txt", "x")
-          requirements = open("demofile2.txt", "a")
+          requirements = open("requirements.txt", "a")
           requirements.write("urllib3<2")
-          requirements = open("demofile2.txt", "a")
+          requirements = open("requirements.txt", "a")
           requirements.write("requests==2.31.0")
           # pip install falconpy package to /tmp/ and add to path
           subprocess.call('pip install crowdstrike-falconpy -r /tmp/requirements.txt -t /tmp/ --no-cache-dir'.split(), stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)


### PR DESCRIPTION
- Updated runtime in RegisterAccountLambda to python3.11
- Added logic to lambda code to create requirements.txt file with required packages for python3.11